### PR TITLE
feat: production ready docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,11 @@ WWWUSER=1000
 WWWGROUP=1000
 
 GITHUB_WEBHOOK_SECRET=
+
+# For use with docker-compose.production.yml
+DOCKER_EXPOSED_HTTP_PORT=80
+DOCKER_EXPOSED_HTTPS_PORT=443
+DOCKER_SSL_ACME_EMAIL=
+DOCKER_DOMAIN_WEB=polypack.example.com
+DOCKER_DOMAIN_MINIO_API=s3.polypack.example.com
+DOCKER_DOMAIN_MINIO_CONSOLE=s3-console.polypack.example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM serversideup/php:8.4-fpm-nginx-alpine
+
+USER root
+
+RUN install-php-extensions intl
+
+USER www-data
+
+COPY --chown=www-data:www-data . /var/www/html
+
+RUN cd /var/www/html && composer install

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Open-source project with the flexibility to adapt to your unique requirements.
 | **PyPI**          | 🚧 Planned |
 | More Coming Soon  | [Request a provider](https://github.com/polypack-io/polypack/issues)  |
 
+## Using Polypack
+[See our installation documentation here](https://polypack.io/docs/installation/)
+
 ## Branching
 
 We use [git-flow](https://nvie.com/posts/a-successful-git-branching-model/) to maintain a standard workflow across developers. Our base branch is "develop". See "main" for the latest stable release, and specific version tags for anything older.

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,195 @@
+services:
+    traefik:
+        image: "traefik:v3.3"
+        container_name: "traefik"
+        command:
+            - "--log.level=DEBUG"
+            - "--accesslog=true"
+            - "--accesslog.addinternals"
+            - "--api=true"
+            - "--api.insecure=true"
+            - "--providers.docker=true"
+            - "--providers.docker.exposedbydefault=false"
+            - "--entryPoints.web.address=:${DOCKER_EXPOSED_HTTP_PORT:-80}"
+            - "--entryPoints.websecure.address=:${DOCKER_EXPOSED_HTTPS_PORT:-443}"
+            - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+            - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+            # Enable using the letsencrypt staging environment for testing
+            # - "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+            - "--certificatesresolvers.letsencrypt.acme.email=${DOCKER_SSL_ACME_EMAIL}"
+            - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+        ports:
+            - "${DOCKER_APP_HTTP_PORT:-80}:80"
+            - "${DOCKER_APP_HTTPS_PORT:-443}:443"
+            - 8080:8080
+        volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+            - "polypack-letsencrypt:/letsencrypt"
+        networks:
+            - polypack
+
+    # We'll reuse the pre-built Laravel image for web, Reverb and Horizon
+    polypack-base: &polypack-base
+        build:
+            context: .
+            dockerfile: Dockerfile
+
+    polypack-web:
+        <<: *polypack-base
+        restart: always
+        environment:
+            WWWUSER: '${WWWUSER}'
+            WWWGROUP: '${WWWGROUP}'
+            PHP_OPCACHE_ENABLE: 1
+            SSL_MODE: "off"
+            AUTORUN_ENABLED: true
+            AUTORUN_LARAVEL_VIEW_CACHE: false
+        depends_on:
+            - pgsql
+            - valkey
+            - typesense
+            - mailpit
+            - minio
+        networks:
+            - polypack
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.polypack-web.tls=true"
+            - "traefik.http.routers.polypack-web.tls.certResolver=letsencrypt"
+            - "traefik.http.routers.polypack-web.entrypoints=websecure"
+            - "traefik.http.routers.polypack-web.rule=Host(`${DOCKER_DOMAIN_WEB}`)"
+            - "traefik.http.services.polypack-web.loadbalancer.server.port=8080"
+            - "traefik.http.services.polypack-web.loadbalancer.server.scheme=http"
+    polypack-queue:
+        <<: *polypack-base
+        restart: always
+        command: ["php", "/var/www/html/artisan", "queue:work", "--tries=3"]
+        stop_signal: SIGTERM # Set this for graceful shutdown if you're using fpm-apache or fpm-nginx
+        environment:
+            WWWUSER: '${WWWUSER}'
+            WWWGROUP: '${WWWGROUP}'
+            PHP_OPCACHE_ENABLE: 1
+        depends_on:
+            - pgsql
+            - valkey
+            - typesense
+            - mailpit
+            - minio
+        networks:
+            - polypack
+        healthcheck:
+            test: ["CMD", "healthcheck-queue"]
+            start_period: 10s
+    pgsql:
+        image: 'postgres:17'
+        restart: always
+        environment:
+            PGPASSWORD: '${DB_PASSWORD:-secret}'
+            POSTGRES_DB: '${DB_DATABASE}'
+            POSTGRES_USER: '${DB_USERNAME}'
+            POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
+        volumes:
+            - 'polypack-pgsql:/var/lib/postgresql/data'
+        networks:
+            - polypack
+        healthcheck:
+            test:
+                - CMD
+                - pg_isready
+                - '-q'
+                - '-d'
+                - '${DB_DATABASE}'
+                - '-U'
+                - '${DB_USERNAME}'
+            retries: 3
+            timeout: 5s
+    valkey:
+        image: 'valkey/valkey:alpine'
+        restart: always
+        volumes:
+            - 'polypack-valkey:/data'
+        networks:
+            - polypack
+        healthcheck:
+            test:
+                - CMD
+                - valkey-cli
+                - ping
+            retries: 3
+            timeout: 5s
+    typesense:
+        image: 'typesense/typesense:27.1'
+        restart: always
+        environment:
+            TYPESENSE_DATA_DIR: '${TYPESENSE_DATA_DIR:-/typesense-data}'
+            TYPESENSE_API_KEY: '${TYPESENSE_API_KEY:-xyz}'
+            TYPESENSE_ENABLE_CORS: '${TYPESENSE_ENABLE_CORS:-true}'
+        volumes:
+            - 'polypack-typesense:/typesense-data'
+        networks:
+            - polypack
+        healthcheck:
+            test:
+                - CMD
+                - wget
+                - '--no-verbose'
+                - '--spider'
+                - 'http://localhost:8108/health'
+            retries: 5
+            timeout: 7s
+    mailpit:
+        image: 'axllent/mailpit:latest'
+        restart: always
+        networks:
+            - polypack
+    minio:
+        image: 'minio/minio:latest'
+        restart: always
+        environment:
+            MINIO_ROOT_USER: polypack
+            MINIO_ROOT_PASSWORD: password
+        volumes:
+            - 'polypack-minio:/data'
+        networks:
+            - polypack
+        command: 'minio server /data --console-address ":8900"'
+        healthcheck:
+            test:
+                - CMD
+                - mc
+                - ready
+                - local
+            retries: 3
+            timeout: 5s
+        labels:
+            # For use with SDKs
+            - "traefik.enable=true"
+            - "traefik.http.routers.polypack-minio-api.tls=true"
+            - "traefik.http.routers.polypack-minio-api.tls.certResolver=letsencrypt"
+            - "traefik.http.routers.polypack-minio-api.entrypoints=websecure"
+            - "traefik.http.routers.polypack-minio-api.rule=Host(`${DOCKER_DOMAIN_MINIO_API}`)"
+            - "traefik.http.routers.polypack-minio-api.service=polypack-minio-api"
+            - "traefik.http.services.polypack-minio-api.loadbalancer.server.port=9000"
+            - "traefik.http.services.polypack-minio-api.loadbalancer.server.scheme=http"
+            # For accessing the console UI
+            - "traefik.http.routers.polypack-minio-console.tls=true"
+            - "traefik.http.routers.polypack-minio-console.tls.certResolver=letsencrypt"
+            - "traefik.http.routers.polypack-minio-console.entrypoints=websecure"
+            - "traefik.http.routers.polypack-minio-console.rule=Host(`${DOCKER_DOMAIN_MINIO_CONSOLE}`)"
+            - "traefik.http.routers.polypack-minio-console.service=polypack-minio-console"
+            - "traefik.http.services.polypack-minio-console.loadbalancer.server.port=8900"
+            - "traefik.http.services.polypack-minio-console.loadbalancer.server.scheme=http"
+networks:
+    polypack:
+        driver: bridge
+volumes:
+    polypack-letsencrypt:
+        driver: local
+    polypack-pgsql:
+        driver: local
+    polypack-valkey:
+        driver: local
+    polypack-typesense:
+        driver: local
+    polypack-minio:
+        driver: local

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker compose -f docker-compose.production.yml up -d --build --force-recreate

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Check if docker is installed
+if ! command -v docker 2>&1 >/dev/null
+then
+  echo "Docker could not be found. Install Docker using with help from their documentation https://docs.docker.com/engine/install/."
+  exit 1
+fi
+
+# Ask for an email address to provide to Let's Encrypt
+read -p "What email address should be provided to Let's Encrypt when provisioning SSL certificates? " email_address
+echo $email_address
+
+http_port=80
+https_port=443
+
+# Ask if HTTP and HTTPS are on default ports
+read -p "Do you wish to use the standard HTTP and HTTPS ports (yes/no)? " use_standard_web_ports
+echo $use_standard_web_ports
+
+if [ "$use_standard_web_ports" != 'yes' ]; then
+  read -p "Which port do you want to use for HTTP traffic (80 by default)? " http_port
+  read -p "Which port do you want to use for HTTPS traffic (443 by default)? " https_port
+fi
+
+# Ask for the full domain to be used to access Polypack
+read -p "What is the domain you wish to use to access Polypack? " domain_polypack
+echo $domain_polypack
+
+# Ask for the full domain to be used to access Minio Object Storage API
+read -p "What is the domain you wish to use to access the Minio Object Storage API? " domain_s3_api
+echo $domain_s3_api
+
+# Ask for the full domain to be used to access Minio Object Storage API
+read -p "What is the domain you wish to use to access the Minio Object Storage API? " domain_s3_console
+echo $domain_s3_console
+
+# If .env doesn't exist, copy .env.example
+if [ ! -f ./.env ]; then
+  echo ".env does not exist, copying .env.example"
+  cp .env.example .env
+fi
+
+sed -i "s/DOCKER_EXPOSED_HTTP_PORT.*/DOCKER_EXPOSED_HTTP_PORT=$http_port/" .env
+sed -i "s/DOCKER_EXPOSED_HTTPS_PORT.*/DOCKER_EXPOSED_HTTPS_PORT=$https_port/" .env
+sed -i "s/DOCKER_SSL_ACME_EMAIL.*/DOCKER_SSL_ACME_EMAIL=$email_address/" .env
+sed -i "s/DOCKER_DOMAIN_WEB.*/DOCKER_DOMAIN_WEB=$domain_polypack/" .env
+sed -i "s/DOCKER_DOMAIN_MINIO_API.*/DOCKER_DOMAIN_MINIO_API=$domain_s3_api/" .env
+sed -i "s/DOCKER_DOMAIN_MINIO_CONSOLE.*/DOCKER_DOMAIN_MINIO_CONSOLE=$domain_s3_console/" .env
+
+docker compose -f docker-compose.production.yml up -d --force-recreate --build
+
+read -p "Do you want to seed the database with an initial login (yes/no)? " seed_db
+if [ "$seed_db" == 'yes' ]; then
+  docker compose -f docker-compose.production.yml exec -it polypack-web php artisan db:seed
+fi


### PR DESCRIPTION
This adds a simple `docker-compose.production.yml` and `setup.sh` for quickly going from nothing to a full production-ready deployment.

This uses the default .env.example, and modifies the `DOCKER_*` variables with data from the user, provided in `setup.sh`.

We can likely tweak this as we don't currently use typesense and we do want add Horizon and Reverb, but support for those should be added in their respective PRs.